### PR TITLE
Allow the user to inject the function used to read source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Gitlab influenced way of composing yaml files by using the `include` keyword
 
-## Usage
+## Usage via CLI
 
 Install package globally.
 ```
@@ -38,3 +38,19 @@ Alternativly you can also use npx and not install it globally.
 ```
 $ npx yaml-compose source.yaml -o dist
 ```
+
+## Usage as a module
+
+Example:
+```
+const { build: yamlCompose } = require('yaml-compose')
+const yaml = await build('source.yml' )
+```
+
+The build function has two arguments `build(sourceFile, options)`:
+-`sourceFile`: The path to the source file
+- `options`: An options object with two recognized properties:
+    - `getFile`: An async function used to read yaml files (i.e. the original source and all included files)  
+      Defaults to `src => fs.readFileSync(src, 'utf-8')`
+    - `resolvePath`: Function used to resolve the relative path given for includes in the source file.   
+      Defaults to `(sourcePath, includePath) => path.resolve(path.dirname(sourcePath), includePath)`  

--- a/cli.js
+++ b/cli.js
@@ -24,15 +24,15 @@ if (!source) {
   process.exit(1)
 }
 
-try {
-  const yaml = build(source)
+build(source)
+  .then(yaml => {
+    if (distDir && !fs.existsSync(distDir)) {
+      fs.mkdirSync(distDir)
+    }
 
-  if (distDir && !fs.existsSync(distDir)) {
-    fs.mkdirSync(distDir)
-  }
-
-  fs.writeFileSync(path.join(process.cwd(), distDir, path.basename(source)), yaml)
-} catch (err) {
-  console.log('Failed to compose YAML file', err.message)
-  process.exit(1)
-}
+    fs.writeFileSync(path.join(process.cwd(), distDir, path.basename(source)), yaml)
+  })
+  .catch(err => {
+    console.log('Failed to compose YAML file', err.message)
+    process.exit(1)
+  })

--- a/lib/__tests__/yaml-compose.js
+++ b/lib/__tests__/yaml-compose.js
@@ -5,22 +5,22 @@ const { build } = require('../yaml-compose')
 const fixturePath = path.join(__dirname, 'fixtures')
 
 describe('build', () => {
-  it('should throw error if source is missing', () => {
-    expect(() => build()).toThrowError()
+  it('should throw error if source is missing', async () => {
+    expect(build()).rejects.toThrow(/TypeError/)
   })
 
-  it('should handle files without includes', () => {
+  it('should handle files without includes', async () => {
     const singleFilePath = path.join(fixturePath, 'no-include', 'source.yml')
-    expect(build(singleFilePath)).toMatchSnapshot()
+    expect(await build(singleFilePath)).toMatchSnapshot()
   })
 
-  it('should include single file', () => {
+  it('should include single file', async () => {
     const singleFilePath = path.join(fixturePath, 'single-include', 'source.yml')
-    expect(build(singleFilePath)).toMatchSnapshot()
+    expect(await build(singleFilePath)).toMatchSnapshot()
   })
 
-  it('should include multiple file', () => {
+  it('should include multiple file', async () => {
     const singleFilePath = path.join(fixturePath, 'array-include', 'source.yml')
-    expect(build(singleFilePath)).toMatchSnapshot()
+    expect(await build(singleFilePath)).toMatchSnapshot()
   })
 })

--- a/lib/yaml-compose.js
+++ b/lib/yaml-compose.js
@@ -10,27 +10,28 @@ const readFile = src => fs.readFileSync(src, 'utf-8')
 
 const loadYaml = str => yaml.safeLoad(str)
 
-const mapToSourcePath = sourceDir => p => path.resolve(sourceDir, p)
+const mapToSourcePath = (sourcePath, includePath) => path.resolve(path.dirname(sourcePath), includePath)
 
-const build = (source) => {
+const build = async (
+  source,
+  { getFile = readFile, resolvePath = mapToSourcePath } = {}
+) => {
   if (typeof source !== 'string') {
     throw new TypeError(`Expected source to be of type string`)
   }
 
-  const yamlString = readFile(source)
+  const yamlString = await getFile(source)
   const yamlJSON = loadYaml(yamlString)
 
   if (!yamlJSON.include) {
     return yamlString
   }
 
-  const sourceDir = path.dirname(source)
-
   // no nested includes
-  const includes = arrayify(yamlJSON.include)
-    .map(mapToSourcePath(sourceDir))
-    .map(readFile)
-    .map(loadYaml)
+  const absolutePaths = arrayify(yamlJSON.include)
+    .map(includePath => resolvePath(source, includePath))
+  const files = await Promise.all(absolutePaths.map(getFile))
+  const includes = files.map(loadYaml)
 
   // delete include directive
   delete yamlJSON.include


### PR DESCRIPTION
BREAKING: build is now async

- The user can supply a `getFile` function (and a corresponding
`resolvePath` function) as an option to build.
  This allows to read files from other sources than the file
  system (i.e. remote sources, filter functions etc)
  `readFileSync` and `path.resolve` are used by default, so the cli
  works as before.
- Update tests
- Update readme
- Update cli to call build with Promise api